### PR TITLE
fix typo in theme functions.

### DIFF
--- a/theme/views_slideshow.theme.inc
+++ b/theme/views_slideshow.theme.inc
@@ -206,7 +206,7 @@ function theme_views_slideshow_pager_widget_render($vss_id, $view, $settings, $l
             function ($m) {
               return strtoupper($m[1]);
             },
-            $vars['settings']['type']),
+            $settings['type']),
           ),
         ),
       ),
@@ -307,7 +307,7 @@ function theme_views_slideshow_controls_widget_render($vss_id, $view, $settings,
             function ($m) {
               return strtoupper($m[1]);
             },
-            $vars['settings']['type']),
+            $settings['type']),
          ),
         ),
       ),


### PR DESCRIPTION
d5677fe1b54b87c87ea72de96254139d0f1d0978 introduced 2 typos that caused the pager highlighting to break. $vars is undefined. 