### PR TITLE
Issue #2835052 by JamesOakley: Fatal error when using top / bottom wi…

### DIFF
--- a/theme/views_slideshow.theme.inc
+++ b/theme/views_slideshow.theme.inc
@@ -139,8 +139,8 @@ function _views_slideshow_preprocess_views_slideshow(&$vars) {
 
     // Build weights
     for ($i = 1; $i <= count($widgets); $i++) {
-      $weight['top'][$i] = '';
-      $weight['bottom'][$i] = '';
+      $weight['top'][$i] = array();
+      $weight['bottom'][$i] = array();
     }
 
     foreach($widgets as $widget_id => $widget_name) {


### PR DESCRIPTION
…dgets with PHP 7.1

Cherry-picked this commit:
https://git.drupalcode.org/project/views_slideshow/-/commit/6d4514e

To fix [Fatal error when using top / bottom widgets with PHP 7.1](https://www.drupal.org/project/views_slideshow/issues/2835052)

